### PR TITLE
fluid_boxes, make mk2 fluids go faster

### DIFF
--- a/prototypes/entity/offshore-pump.lua
+++ b/prototypes/entity/offshore-pump.lua
@@ -17,6 +17,18 @@ mk2.name = "offshore-pump-mk2"
 mk2.minable.result = mk2.name
 mk2.max_health = 300
 mk2.pumping_speed = 40
+
+if mk2.fluid_box.base then
+    mk2.fluid_box.base = mk2.fluid_box.base * 2
+else
+    mk2.fluid_box.base = 2
+end
+if mk2.fluid_box.height then
+    mk2.fluid_box.height = mk2.fluid_box.height * 2
+else
+    mk2.fluid_box.height = 2
+end
+
 mk2.icons = {
     {
         icon = mk2.icon,

--- a/prototypes/entity/pipe-to-ground.lua
+++ b/prototypes/entity/pipe-to-ground.lua
@@ -11,6 +11,17 @@ mk2.minable.result = mk2.name
 mk2.max_health = 200
 mk2.fluid_box.pipe_connections[2].max_underground_distance = 20
 
+if mk2.fluid_box.base then
+    mk2.fluid_box.base = mk2.fluid_box.base * 2
+else
+    mk2.fluid_box.base = 2
+end
+if mk2.fluid_box.height then
+    mk2.fluid_box.height = mk2.fluid_box.height * 2
+else
+    mk2.fluid_box.height = 2
+end
+
 for _, direction in pairs({"north", "east", "south", "west"}) do
     mk2.fluid_box.pipe_covers[direction].layers[1].filename = "__FactorioExtended-Plus-Transport__/graphics/entity/pipe-covers/pipe-cover-" .. direction .. ".png"
     mk2.fluid_box.pipe_covers[direction].layers[1].hr_version.filename = "__FactorioExtended-Plus-Transport__/graphics/entity/pipe-covers/hr-pipe-cover-" .. direction .. ".png"

--- a/prototypes/entity/pipe.lua
+++ b/prototypes/entity/pipe.lua
@@ -10,6 +10,17 @@ mk2.icon_mipmaps = nil
 mk2.minable.result = mk2.name
 mk2.max_health = 200
 
+if mk2.fluid_box.base then
+    mk2.fluid_box.base = mk2.fluid_box.base * 2
+else
+    mk2.fluid_box.base = 2
+end
+if mk2.fluid_box.height then
+    mk2.fluid_box.height = mk2.fluid_box.height * 2
+else
+    mk2.fluid_box.height = 2
+end
+
 mk2.pictures.straight_vertical_single.filename = "__FactorioExtended-Plus-Transport__/graphics/entity/pipe/pipe-straight-vertical-single.png"
 mk2.pictures.straight_vertical_single.hr_version.filename = "__FactorioExtended-Plus-Transport__/graphics/entity/pipe/hr-pipe-straight-vertical-single.png"
 mk2.pictures.straight_vertical.filename = "__FactorioExtended-Plus-Transport__/graphics/entity/pipe/pipe-straight-vertical.png"

--- a/prototypes/entity/pump.lua
+++ b/prototypes/entity/pump.lua
@@ -15,6 +15,17 @@ mk2.energy_source.drain = "1kW"
 mk2.energy_usage = "60kW"
 mk2.pumping_speed = 400
 
+if mk2.fluid_box.base then
+    mk2.fluid_box.base = mk2.fluid_box.base * 2
+else
+    mk2.fluid_box.base = 2
+end
+if mk2.fluid_box.height then
+    mk2.fluid_box.height = mk2.fluid_box.height * 2
+else
+    mk2.fluid_box.height = 2
+end
+
 for _, direction in pairs({"north", "east", "south", "west"}) do
     mk2.animations[direction].filename = "__FactorioExtended-Plus-Transport__/graphics/entity/pump/pump-" .. direction .. ".png"
     mk2.animations[direction].hr_version.filename = "__FactorioExtended-Plus-Transport__/graphics/entity/pump/hr-pump-" .. direction .. ".png"


### PR DESCRIPTION
It was noticed in a playthough that the titaium pipes only benifit was from the extended reach of the underground pipes, they dont actually fill up any faster at the other end.

This change increases the fluid box sizes to allow the fluids to move faster.