### PR TITLE
fixed entity tint, and updated offshore-pump graphics set

### DIFF
--- a/prototypes/entity/offshore-pump.lua
+++ b/prototypes/entity/offshore-pump.lua
@@ -18,6 +18,7 @@ mk2.next_upgrade = nil
 mk2.minable.result = mk2.name
 mk2.max_health = 300
 mk2.pumping_speed = 40
+mk2.icons = {{icon = mk2.icon, icon_mipmaps = 4, icon_size = 64, tint = Constant.green_tint}}
 
 if mk2.fluid_box.base then
     mk2.fluid_box.base = mk2.fluid_box.base * 2
@@ -31,7 +32,8 @@ else
 end
 
 for _, direction in pairs({"north", "east", "south", "west"}) do
-    mk2.picture[direction].tint = Constant.green_tint
+    mk2.graphics_set.animation[direction].layers[1].tint = Constant.green_tint
+    mk2.graphics_set.animation[direction].layers[1].hr_version.tint = Constant.green_tint
 end
 
 data:extend({mk2})

--- a/prototypes/entity/pipe-to-ground.lua
+++ b/prototypes/entity/pipe-to-ground.lua
@@ -1,3 +1,5 @@
+local Constant = require("constant")
+
 -- pipe-to-ground                               mk1                                 mk2
 -- max_health                                   150                                 200
 --
@@ -7,6 +9,7 @@ mk2.name = "pipe-to-ground-mk2"
 mk2.minable.result = mk2.name
 mk2.max_health = 200
 mk2.fluid_box.pipe_connections[2].max_underground_distance = 20
+mk2.icons = {{icon = mk2.icon, icon_mipmaps = 4, icon_size = 64, tint = Constant.green_tint}}
 
 if mk2.fluid_box.base then
     mk2.fluid_box.base = mk2.fluid_box.base * 2

--- a/prototypes/entity/pipe.lua
+++ b/prototypes/entity/pipe.lua
@@ -1,3 +1,5 @@
+local Constant = require("constant")
+
 -- pipe                                         mk1                                 mk2
 -- max_health                                   100                                 200
 --
@@ -6,6 +8,7 @@ local mk2 = table.deepcopy(data.raw["pipe"]["pipe"])
 mk2.name = "pipe-mk2"
 mk2.minable.result = mk2.name
 mk2.max_health = 200
+mk2.icons = {{icon = mk2.icon, icon_mipmaps = 4, icon_size = 64, tint = Constant.green_tint}}
 
 if mk2.fluid_box.base then
     mk2.fluid_box.base = mk2.fluid_box.base * 2

--- a/prototypes/entity/pump.lua
+++ b/prototypes/entity/pump.lua
@@ -1,3 +1,5 @@
+local Constant = require("constant")
+
 -- pump                                         mk1                                 mk2
 -- max_health                                   180                                 360
 -- energy_source.drain                          1kW                                 1kW
@@ -11,6 +13,7 @@ mk2.max_health = 360
 mk2.energy_source.drain = "1kW"
 mk2.energy_usage = "60kW"
 mk2.pumping_speed = 400
+mk2.icons = {{icon = mk2.icon, icon_mipmaps = 4, icon_size = 64, tint = Constant.green_tint}}
 
 if mk2.fluid_box.base then
     mk2.fluid_box.base = mk2.fluid_box.base * 2


### PR DESCRIPTION
Upgrade planner uses the icon from the entity,  these needed tints applied to show the difference

Also noticed that offshore pump has moved from pictures to using graphics_set